### PR TITLE
Improved Synth construction API, fixed multiple waveform errors and "warbliness" effect.

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -71,8 +71,7 @@ fn main() {
             .loop_points(0.49, 0.51) // Loop start and end points.
             .fade(500.0, 500.0) // Attack and release.
             .num_voices(16) // By default Synth is monophonic but this gives it `n` voice polyphony.
-
-        // Other methods include...
+        // Other methods include:
             // .loop_start(0.0)
             // .loop_end(1.0)
             // .attack(ms)

--- a/src/oscillator.rs
+++ b/src/oscillator.rs
@@ -66,9 +66,9 @@ impl Oscillator {
     #[inline]
     pub fn amp_at_ratio(&mut self, ratio: f64, note_freq_multi: f64, sample_hz: f64) -> f32 {
         let phase = self.phase;
-        // Determine the overall frequency and in turn how much to advance the phase.
         let freq_at_ratio = self.freq_at_ratio(ratio) * note_freq_multi;
-        self.phase = self.waveform.next_phase(phase, freq_at_ratio, sample_hz);
+        // Determine the next phase with respect to frequency and sample rate.
+        self.phase = phase + (freq_at_ratio / sample_hz);
         self.waveform.amp_at_phase(phase) * self.amplitude.y(ratio) as f32
     }
 

--- a/src/waveform.rs
+++ b/src/waveform.rs
@@ -1,7 +1,7 @@
 
 /// An Oscillator must use one of a variety
 /// of waveform types.
-#[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, RustcEncodable, RustcDecodable)]
 pub enum Waveform {
     /// Sine Wave
     Sine,

--- a/src/waveform.rs
+++ b/src/waveform.rs
@@ -17,28 +17,15 @@ pub enum Waveform {
 
 impl Waveform {
 
-    /// Return the new phrase considering the frequency, sample rate and waveform.
-    pub fn next_phase(&self, current_phase: f64, freq: f64, sample_hz: f64) -> f64 {
-        use utils::remainder;
-        let advance_per_sample = freq / sample_hz;
-        match *self {
-            Waveform::Sine      |
-            Waveform::NoiseWalk |
-            Waveform::Square    => current_phase + advance_per_sample,
-            Waveform::Saw   |
-            Waveform::Noise => remainder(current_phase + advance_per_sample, 2.0),
-        }
-    }
-
     /// Return the amplitude of a waveform at a given phase.
     pub fn amp_at_phase(&self, phase: f64) -> f32 {
-        use std::f64::consts::{PI, PI_2};
+        use std::f64::consts::PI_2;
         use std::num::Float;
         use utils::{fmod, noise_walk};
         let amp = match *self {
             Waveform::Sine => (PI_2 * phase).sin(),
             Waveform::Saw => fmod(phase, 1.0) * -2.0 + 1.0,
-            Waveform::Square => if phase < PI { -1.0 } else { 1.0 },
+            Waveform::Square => if (PI_2 * phase).sin() < 0.0 { -1.0 } else { 1.0 },
             Waveform::Noise => ::rand::random::<f64>() * 2.0 - 1.0,
             Waveform::NoiseWalk => noise_walk(phase),
         };


### PR DESCRIPTION
- Synth now uses builder methods for construction.
- Fixed warbliness effect by applying gaussian randomness to the pitch in the form of mels rather than hz.
- Removed unnecessary next_phase fn
- Fixed incorrect Square waveform.
- Tweaked noisewalk frequency enveloping.
- Added pause, unpause and stop methods to Synth.

NOTE: travis may still be broken as code is slightly ahead of nightlies.
