### PR TITLE
Correct the behaviour of the note_stack with detuned notes and more (see body).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "synth"
 description = "A polyphonic Synth type whose multiple oscillators generate sound via amplitude and frequency envelopes."
-version = "0.4.1"
+version = "0.4.2"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["synthesis", "dsp", "audio", "music", "instrument"]

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -166,7 +166,7 @@ impl Voice {
             // Iterate the playhead. If the playhead passes the duration of the instrument or
             // the note that is currently being played, reset the playhead and stop playback.
             *playhead += 1;
-            if *playhead >= duration + release || *loop_playhead > duration {
+            if *loop_playhead > duration {
                 *maybe_note = None;
                 *playhead = 0;
             }


### PR DESCRIPTION
- Change sustained note behaviour to play looped parts continuously until note_off is given.
- Make note_off hz comparisons more stable by checking a short range rather than comparing floats directly
