### PR TITLE
don't spin quite so hard in example

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -10,7 +10,6 @@ extern crate dsp;
 extern crate pitch_calc as pitch;
 extern crate portaudio;
 extern crate synth;
-extern crate time_calc as timec;
 
 use dsp::{Node, Settings};
 use portaudio as pa;

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -10,12 +10,13 @@ extern crate dsp;
 extern crate pitch_calc as pitch;
 extern crate portaudio;
 extern crate synth;
-extern crate time_calc as time;
+extern crate time_calc as timec;
 
 use dsp::{Node, Settings};
 use portaudio as pa;
 use pitch::{Letter, LetterOctave};
 use synth::Synth;
+use std::{thread, time};
 
 // Currently supports i8, i32, f32.
 pub type AudioSample = f32;
@@ -129,8 +130,10 @@ fn run() -> Result<(), pa::Error> {
     let mut stream = try!(pa.open_non_blocking_stream(settings, callback));
     try!(stream.start());
 
+    let ten_millis = time::Duration::from_millis(10);
+
     // Loop while the stream is active.
-    while let Ok(true) = stream.is_active() {}
+    while let Ok(true) = stream.is_active() { thread::sleep(ten_millis); }
 
     Ok(())
 }


### PR DESCRIPTION
When I first started the example I noticed that it was chewing up an entire core and causing underruns.  I took a quick look with perf and found that checking that the stream was active was doing most of the work, so I added a small delay in the busy loop which takes it down to much more acceptable levels of CPU utilization.