### PR TITLE
included `synth::Frames` in pub use so it is accessible for users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub use dynamic::Synth as Dynamic;
 pub use envelope::{Envelope, Point};
 pub use envelope::Trait as EnvelopeTrait;
 pub use oscillator::{AmpEnvelope, FreqEnvelope, Oscillator, Waveform};
-pub use synth::Synth;
+pub use synth::{Synth, Frames};
 
 pub mod dynamic;
 pub mod envelope;


### PR DESCRIPTION
Due to the module `synth` being private, `synth::Frames` isn't directly accessible from the outside, but since it's the return value of  `Synth::frames()`, which is accessible, one cannot type the return type out/ use this furhter. This seems to be unintentional and a bug